### PR TITLE
give log more vertical space in small devices with main menu open

### DIFF
--- a/src/styles/components/_main-nav.scss
+++ b/src/styles/components/_main-nav.scss
@@ -4,7 +4,7 @@
         position:fixed;
         width:100vw;
         height: calc(100vh - 80px);
-        top:80px;
+        top:92px;
         left:0;
         background-color: #EDEDED;
         overflow-y: auto;


### PR DESCRIPTION
With this, users should be able to open the hamburger menu in small devices and still see the whole SUNET logo.

close #11